### PR TITLE
fix(fix-apis): fix apis references

### DIFF
--- a/lib/src/tabs/tabs.component.spec.ts
+++ b/lib/src/tabs/tabs.component.spec.ts
@@ -70,7 +70,6 @@ describe("TabsComponent", () => {
     });
 
     it("Should fire click event if passed", () => {
-        console.log("Other countries ", fixture.debugElement.queryAll(By.css(".nav-link"))[1]);
         fixture.debugElement.queryAll(By.css(".nav-link"))[1].nativeElement.dispatchEvent(new Event("click"));
         expect(onClick).toHaveBeenCalledTimes(1);
     });

--- a/projects/ng-components-docs/src/app/app-routing.module.ts
+++ b/projects/ng-components-docs/src/app/app-routing.module.ts
@@ -16,6 +16,7 @@ import { ROUTES as TABS_ROUTES } from "./examples/components/tabs/tabs.module";
 import { ROUTES as BREADCRUMB_ROUTES } from "./examples/components/breadcrumb/breadcrumb.module";
 
 import { InstallationComponent } from "./components/installation/installation.component";
+import { sortArray } from "./utils/arrayFunctions";
 
 const routes: Routes = [
     {
@@ -40,69 +41,72 @@ const routes: Routes = [
         data: {
             icon: "cubes",
         },
-        children: [
-            {
-                path: "",
-                redirectTo: "buttons",
-                pathMatch: "full",
-            },
-            {
-                path: "radios",
-                children: RADIOS_ROUTES,
-            },
-            {
-                path: "buttons",
-                children: BUTTONS_ROUTES,
-            },
-            {
-                path: "modal",
-                children: MODAL_ROUTES,
-            },
-            {
-                path: "dropdown",
-                children: DROPDOWN_ROUTES,
-            },
-            {
-                path: "wizard",
-                children: WIZARD_ROUTES,
-            },
-            {
-                path: "textLabel",
-                children: TEXTLABEL_ROUTES,
-            },
-            {
-                path: "pagination",
-                children: PAGINATION_ROUTES,
-            },
-            {
-                path: "textarea",
-                children: TEXTAREA_ROUTES,
-            },
-            {
-                path: "textboxGroup",
-                children: TEXTBOXGROUP_ROUTES,
-            },
-            {
-                path: "accordion",
-                children: ACCORDION_ROUTES,
-            },
-            {
-                path: "toggle",
-                children: TOGGLE_ROUTES,
-            },
-            {
-                path: "chip",
-                children: CHIP_ROUTES,
-            },
-            {
-                path: "tabs",
-                children: TABS_ROUTES,
-            },
-            {
-                path: "breadcrumb",
-                children: BREADCRUMB_ROUTES,
-            },
-        ],
+        children: sortArray(
+            [
+                {
+                    path: "",
+                    redirectTo: "buttons",
+                    pathMatch: "full",
+                },
+                {
+                    path: "radios",
+                    children: RADIOS_ROUTES,
+                },
+                {
+                    path: "buttons",
+                    children: BUTTONS_ROUTES,
+                },
+                {
+                    path: "modal",
+                    children: MODAL_ROUTES,
+                },
+                {
+                    path: "dropdown",
+                    children: DROPDOWN_ROUTES,
+                },
+                {
+                    path: "wizard",
+                    children: WIZARD_ROUTES,
+                },
+                {
+                    path: "textLabel",
+                    children: TEXTLABEL_ROUTES,
+                },
+                {
+                    path: "pagination",
+                    children: PAGINATION_ROUTES,
+                },
+                {
+                    path: "textarea",
+                    children: TEXTAREA_ROUTES,
+                },
+                {
+                    path: "textboxGroup",
+                    children: TEXTBOXGROUP_ROUTES,
+                },
+                {
+                    path: "accordion",
+                    children: ACCORDION_ROUTES,
+                },
+                {
+                    path: "toggle",
+                    children: TOGGLE_ROUTES,
+                },
+                {
+                    path: "chip",
+                    children: CHIP_ROUTES,
+                },
+                {
+                    path: "tabs",
+                    children: TABS_ROUTES,
+                },
+                {
+                    path: "breadcrumb",
+                    children: BREADCRUMB_ROUTES,
+                },
+            ],
+            "path"
+        ),
     },
 ];
 

--- a/projects/ng-components-docs/src/app/components/example-page/api-list/api-list.component.ts
+++ b/projects/ng-components-docs/src/app/components/example-page/api-list/api-list.component.ts
@@ -70,7 +70,6 @@ export class ApiListComponent implements OnInit {
     }
     static extractDescription(sourceCode: string) {
         const regex = /(?:\/\*\*(?<comment>[\s\S][^\/]*)\*\/[^\w])/;
-        console.log(sourceCode, regex.exec(sourceCode));
         return regex.exec(sourceCode);
     }
 

--- a/projects/ng-components-docs/src/app/examples/components/accordion/accordion.module.ts
+++ b/projects/ng-components-docs/src/app/examples/components/accordion/accordion.module.ts
@@ -25,12 +25,12 @@ export const ROUTES = [
                             sources: [
                                 {
                                     name: "text-labels.component.html",
-                                    src: require("!raw-loader!./accordion.component.html"),
+                                    src: require("!raw-loader!./accordion.component.html").default,
                                     lang: "markup",
                                 },
                                 {
                                     name: "accordion.component.ts",
-                                    src: require("!raw-loader!./accordion.component.ts"),
+                                    src: require("!raw-loader!./accordion.component.ts").default,
                                     lang: "ts",
                                 },
                             ],
@@ -42,7 +42,7 @@ export const ROUTES = [
                 path: "api",
                 component: ApiListComponent,
                 data: {
-                    sources: [require("!raw-loader!../../../../../../../lib/src/textLabel/textLabel.component.ts")],
+                    sources: [require("!raw-loader!../../../../../../../lib/src/textLabel/textLabel.component.ts").default],
                 },
             },
         ],

--- a/projects/ng-components-docs/src/app/examples/components/breadcrumb/breadcrumb.module.ts
+++ b/projects/ng-components-docs/src/app/examples/components/breadcrumb/breadcrumb.module.ts
@@ -25,12 +25,12 @@ export const ROUTES = [
                             sources: [
                                 {
                                     name: "breadcrumb.component.html",
-                                    src: require("!raw-loader!./breadcrumb.component.html"),
+                                    src: require("!raw-loader!./breadcrumb.component.html").default,
                                     lang: "markup",
                                 },
                                 {
                                     name: "breadcrumb.component.ts",
-                                    src: require("!raw-loader!./breadcrumb.component.ts"),
+                                    src: require("!raw-loader!./breadcrumb.component.ts").default,
                                     lang: "ts",
                                 },
                             ],
@@ -42,7 +42,7 @@ export const ROUTES = [
                 path: "api",
                 component: ApiListComponent,
                 data: {
-                    sources: [require("!raw-loader!../../../../../../../lib/src/breadcrumb/breadcrumb.component.ts")],
+                    sources: [require("!raw-loader!../../../../../../../lib/src/breadcrumb/breadcrumb.component.ts").default],
                 },
             },
         ],

--- a/projects/ng-components-docs/src/app/examples/components/buttons/buttons.module.ts
+++ b/projects/ng-components-docs/src/app/examples/components/buttons/buttons.module.ts
@@ -26,12 +26,12 @@ export const ROUTES: Array<Route> = [
                             sources: [
                                 {
                                     name: "buttons.component.html",
-                                    src: require("!raw-loader!./examples/buttons/buttons.component.html"),
+                                    src: require("!raw-loader!./examples/buttons/buttons.component.html").default,
                                     lang: "markup",
                                 },
                                 {
                                     name: "buttons.component.ts",
-                                    src: require("!raw-loader!./examples/buttons/buttons.component.ts"),
+                                    src: require("!raw-loader!./examples/buttons/buttons.component.ts").default,
                                     lang: "ts",
                                 },
                             ],
@@ -75,7 +75,7 @@ export const ROUTES: Array<Route> = [
                 path: "api",
                 component: ApiListComponent,
                 data: {
-                    sources: [require("!raw-loader!../../../../../../../lib/src/button/button.ts")],
+                    sources: [require("!raw-loader!../../../../../../../lib/src/button/button.ts").default],
                 },
             },
         ],

--- a/projects/ng-components-docs/src/app/examples/components/chip/chip.module.ts
+++ b/projects/ng-components-docs/src/app/examples/components/chip/chip.module.ts
@@ -25,12 +25,12 @@ export const ROUTES = [
                             sources: [
                                 {
                                     name: "chip.component.html",
-                                    src: require("!raw-loader!./chip.component.html"),
+                                    src: require("!raw-loader!./chip.component.html").default,
                                     lang: "markup",
                                 },
                                 {
                                     name: "chip.component.ts",
-                                    src: require("!raw-loader!./chip.component.ts"),
+                                    src: require("!raw-loader!./chip.component.ts").default,
                                     lang: "ts",
                                 },
                             ],
@@ -42,7 +42,7 @@ export const ROUTES = [
                 path: "api",
                 component: ApiListComponent,
                 data: {
-                    sources: [require("!raw-loader!../../../../../../../lib/src/chip/chip.component.ts")],
+                    sources: [require("!raw-loader!../../../../../../../lib/src/chip/chip.component.ts").default],
                 },
             },
         ],

--- a/projects/ng-components-docs/src/app/examples/components/dropdown/dropdown.module.ts
+++ b/projects/ng-components-docs/src/app/examples/components/dropdown/dropdown.module.ts
@@ -26,12 +26,12 @@ export const ROUTES: Array<Route> = [
                             sources: [
                                 {
                                     name: "dropdowns.component.html",
-                                    src: require("!raw-loader!./examples/dropdowns/dropdowns.component.html"),
+                                    src: require("!raw-loader!./examples/dropdowns/dropdowns.component.html").default,
                                     lang: "markup",
                                 },
                                 {
                                     name: "dropdowns.component.ts",
-                                    src: require("!raw-loader!./examples/dropdowns/dropdowns.component.ts"),
+                                    src: require("!raw-loader!./examples/dropdowns/dropdowns.component.ts").default,
                                     lang: "ts",
                                 },
                             ],
@@ -43,7 +43,7 @@ export const ROUTES: Array<Route> = [
                 path: "api",
                 component: ApiListComponent,
                 data: {
-                    sources: [require("!raw-loader!../../../../../../../lib/src/dropdown/dropdown.component.ts")],
+                    sources: [require("!raw-loader!../../../../../../../lib/src/dropdown/dropdown.component.ts").default],
                 },
             },
         ],

--- a/projects/ng-components-docs/src/app/examples/components/modal/modal.module.ts
+++ b/projects/ng-components-docs/src/app/examples/components/modal/modal.module.ts
@@ -25,13 +25,13 @@ export const ROUTES = [
                                 {
                                     name: "modal.component.html",
                                     // @ts-ignore
-                                    src: require("!raw-loader!./examples/modal/modal.component.html"),
+                                    src: require("!raw-loader!./examples/modal/modal.component.html").default,
                                     lang: "markup",
                                 },
                                 {
                                     name: "modal.component.ts",
                                     // @ts-ignore
-                                    src: require("!raw-loader!./examples/modal/modal.component.ts"),
+                                    src: require("!raw-loader!./examples/modal/modal.component.ts").default,
                                     lang: "ts",
                                 },
                             ],
@@ -44,10 +44,11 @@ export const ROUTES = [
                 component: ApiListComponent,
                 data: {
                     sources: [
-                        require("!raw-loader!../../../../../../../lib/src/button/parse-source-example/parse-source-example.component.ts"),
-                        require("!raw-loader!../../../../../../../lib/src/modal/modal.ts"),
-                        require("!raw-loader!../../../../../../../lib/src/modal/modal.directives.ts"),
-                        require("!raw-loader!../../../../../../../lib/src/modal/modal.service.ts"),
+                        require("!raw-loader!../../../../../../../lib/src/button/parse-source-example/parse-source-example.component.ts")
+                            .default,
+                        require("!raw-loader!../../../../../../../lib/src/modal/modal.ts").default,
+                        require("!raw-loader!../../../../../../../lib/src/modal/modal.directives.ts").default,
+                        require("!raw-loader!../../../../../../../lib/src/modal/modal.service.ts").default,
                     ],
                 },
             },

--- a/projects/ng-components-docs/src/app/examples/components/pagination/pagination.module.ts
+++ b/projects/ng-components-docs/src/app/examples/components/pagination/pagination.module.ts
@@ -26,12 +26,12 @@ export const ROUTES: Array<Route> = [
                             sources: [
                                 {
                                     name: "pagintaion.component.html",
-                                    src: require("!raw-loader!./examples/pagination/pagination.component.html"),
+                                    src: require("!raw-loader!./examples/pagination/pagination.component.html").default,
                                     lang: "markup",
                                 },
                                 {
                                     name: "pagination.component.ts",
-                                    src: require("!raw-loader!./examples/pagination/pagination.component.ts"),
+                                    src: require("!raw-loader!./examples/pagination/pagination.component.ts").default,
                                     lang: "ts",
                                 },
                             ],
@@ -43,7 +43,7 @@ export const ROUTES: Array<Route> = [
                 path: "api",
                 component: ApiListComponent,
                 data: {
-                    sources: [require("!raw-loader!../../../../../../../lib/src/pagination/pagination.component.ts")],
+                    sources: [require("!raw-loader!../../../../../../../lib/src/pagination/pagination.component.ts").default],
                 },
             },
         ],

--- a/projects/ng-components-docs/src/app/examples/components/radio-group/radio-group.module.ts
+++ b/projects/ng-components-docs/src/app/examples/components/radio-group/radio-group.module.ts
@@ -27,12 +27,12 @@ export const ROUTES: Array<Route> = [
                             sources: [
                                 {
                                     name: "radio-groups.component.html",
-                                    src: require("!raw-loader!./examples/radio-groups/radio-groups.component.html"),
+                                    src: require("!raw-loader!./examples/radio-groups/radio-groups.component.html").default,
                                     lang: "markup",
                                 },
                                 {
                                     name: "radio-groups.component.ts",
-                                    src: require("!raw-loader!./examples/radio-groups/radio-groups.component.ts"),
+                                    src: require("!raw-loader!./examples/radio-groups/radio-groups.component.ts").default,
                                     lang: "ts",
                                 },
                             ],
@@ -44,7 +44,7 @@ export const ROUTES: Array<Route> = [
                 path: "api",
                 component: ApiListComponent,
                 data: {
-                    sources: [require("!raw-loader!../../../../../../../lib/src/radio-group/radio-group.component.ts")],
+                    sources: [require("!raw-loader!../../../../../../../lib/src/radio-group/radio-group.component.ts").default],
                 },
             },
         ],

--- a/projects/ng-components-docs/src/app/examples/components/tabs/examples/tabs/tabs.component.ts
+++ b/projects/ng-components-docs/src/app/examples/components/tabs/examples/tabs/tabs.component.ts
@@ -10,7 +10,6 @@ export class TabsComponent {
     activeTab: number = 0;
 
     onClick(index: number) {
-        console.log("Village ", index);
         this.activeTab = index;
     }
 }

--- a/projects/ng-components-docs/src/app/examples/components/tabs/tabs.module.ts
+++ b/projects/ng-components-docs/src/app/examples/components/tabs/tabs.module.ts
@@ -26,12 +26,12 @@ export const ROUTES: Array<Route> = [
                             sources: [
                                 {
                                     name: "tabs.component.html",
-                                    src: require("!raw-loader!./examples/tabs/tabs.component.html"),
+                                    src: require("!raw-loader!./examples/tabs/tabs.component.html").default,
                                     lang: "markup",
                                 },
                                 {
                                     name: "pagination.component.ts",
-                                    src: require("!raw-loader!./examples/tabs/tabs.component.ts"),
+                                    src: require("!raw-loader!./examples/tabs/tabs.component.ts").default,
                                     lang: "ts",
                                 },
                             ],
@@ -43,7 +43,7 @@ export const ROUTES: Array<Route> = [
                 path: "api",
                 component: ApiListComponent,
                 data: {
-                    sources: [require("!raw-loader!../../../../../../../lib/src/tabs/tabs.component.ts")],
+                    sources: [require("!raw-loader!../../../../../../../lib/src/tabs/tabs.component.ts").default],
                 },
             },
         ],

--- a/projects/ng-components-docs/src/app/examples/components/textArea/textArea.module.ts
+++ b/projects/ng-components-docs/src/app/examples/components/textArea/textArea.module.ts
@@ -27,12 +27,12 @@ export const ROUTES: Array<Route> = [
                             sources: [
                                 {
                                     name: "textArea.component.html",
-                                    src: require("!raw-loader!./examples/textArea/textArea.component.html"),
+                                    src: require("!raw-loader!./examples/textArea/textArea.component.html").default,
                                     lang: "markup",
                                 },
                                 {
                                     name: "pagination.component.ts",
-                                    src: require("!raw-loader!./examples/textArea/textArea.component.ts"),
+                                    src: require("!raw-loader!./examples/textArea/textArea.component.ts").default,
                                     lang: "ts",
                                 },
                             ],
@@ -44,7 +44,7 @@ export const ROUTES: Array<Route> = [
                 path: "api",
                 component: ApiListComponent,
                 data: {
-                    sources: [require("!raw-loader!../../../../../../../lib/src/textArea/textArea.component.ts")],
+                    sources: [require("!raw-loader!../../../../../../../lib/src/textArea/textArea.component.ts").default],
                 },
             },
         ],

--- a/projects/ng-components-docs/src/app/examples/components/textLabels/text-labels.module.ts
+++ b/projects/ng-components-docs/src/app/examples/components/textLabels/text-labels.module.ts
@@ -25,12 +25,12 @@ export const ROUTES = [
                             sources: [
                                 {
                                     name: "text-labels.component.html",
-                                    src: require("!raw-loader!./text-labels.component.html"),
+                                    src: require("!raw-loader!./text-labels.component.html").default,
                                     lang: "markup",
                                 },
                                 {
                                     name: "text-labels.component.ts",
-                                    src: require("!raw-loader!./text-labels.component.ts"),
+                                    src: require("!raw-loader!./text-labels.component.ts").default,
                                     lang: "ts",
                                 },
                             ],
@@ -42,7 +42,7 @@ export const ROUTES = [
                 path: "api",
                 component: ApiListComponent,
                 data: {
-                    sources: [require("!raw-loader!../../../../../../../lib/src/textLabel/textLabel.component.ts")],
+                    sources: [require("!raw-loader!../../../../../../../lib/src/textLabel/textLabel.component.ts").default],
                 },
             },
         ],

--- a/projects/ng-components-docs/src/app/examples/components/textboxGroup/textboxGroup.module.ts
+++ b/projects/ng-components-docs/src/app/examples/components/textboxGroup/textboxGroup.module.ts
@@ -26,12 +26,12 @@ export const ROUTES: Array<Route> = [
                             sources: [
                                 {
                                     name: "textboxGroup.component.html",
-                                    src: require("!raw-loader!./examples/textboxGroup/textboxGroup.component.html"),
+                                    src: require("!raw-loader!./examples/textboxGroup/textboxGroup.component.html").default,
                                     lang: "markup",
                                 },
                                 {
                                     name: "textboxGroup.component.ts",
-                                    src: require("!raw-loader!./examples/textboxGroup/textboxGroup.component.ts"),
+                                    src: require("!raw-loader!./examples/textboxGroup/textboxGroup.component.ts").default,
                                     lang: "ts",
                                 },
                             ],
@@ -43,7 +43,7 @@ export const ROUTES: Array<Route> = [
                 path: "api",
                 component: ApiListComponent,
                 data: {
-                    sources: [require("!raw-loader!../../../../../../../lib/src/textboxGroup/textboxGroup.component.ts")],
+                    sources: [require("!raw-loader!../../../../../../../lib/src/textboxGroup/textboxGroup.component.ts").default],
                 },
             },
         ],

--- a/projects/ng-components-docs/src/app/examples/components/toggle/toggle.module.ts
+++ b/projects/ng-components-docs/src/app/examples/components/toggle/toggle.module.ts
@@ -27,12 +27,12 @@ export const ROUTES: Array<Route> = [
                             sources: [
                                 {
                                     name: "toggle.component.html",
-                                    src: require("!raw-loader!./examples/toggle/toggle.component.html"),
+                                    src: require("!raw-loader!./examples/toggle/toggle.component.html").default,
                                     lang: "markup",
                                 },
                                 {
                                     name: "toggle.component.ts",
-                                    src: require("!raw-loader!./examples/toggle/toggle.component.ts"),
+                                    src: require("!raw-loader!./examples/toggle/toggle.component.ts").default,
                                     lang: "ts",
                                 },
                             ],
@@ -44,7 +44,7 @@ export const ROUTES: Array<Route> = [
                 path: "api",
                 component: ApiListComponent,
                 data: {
-                    sources: [require("!raw-loader!../../../../../../../lib/src/toggle/toggle.component.ts")],
+                    sources: [require("!raw-loader!../../../../../../../lib/src/toggle/toggle.component.ts").default],
                 },
             },
         ],

--- a/projects/ng-components-docs/src/app/examples/components/wizard/wizard.module.ts
+++ b/projects/ng-components-docs/src/app/examples/components/wizard/wizard.module.ts
@@ -30,22 +30,22 @@ export const ROUTES: Array<Route> = [
                             sources: [
                                 {
                                     name: "wizard.component.html",
-                                    src: require("!raw-loader!./examples/wizard/wizard.component.html"),
+                                    src: require("!raw-loader!./examples/wizard/wizard.component.html").default,
                                     lang: "markup",
                                 },
                                 {
                                     name: "wizard.component.ts",
-                                    src: require("!raw-loader!./examples/wizard/wizard.component.ts"),
+                                    src: require("!raw-loader!./examples/wizard/wizard.component.ts").default,
                                     lang: "ts",
                                 },
                                 {
                                     name: "wizard-forms.component.html",
-                                    src: require("!raw-loader!./examples/wizard-forms/wizard-forms.component.html"),
+                                    src: require("!raw-loader!./examples/wizard-forms/wizard-forms.component.html").default,
                                     lang: "markup",
                                 },
                                 {
                                     name: "wizard-forms.component.ts",
-                                    src: require("!raw-loader!./examples/wizard-forms/wizard-forms.component.ts"),
+                                    src: require("!raw-loader!./examples/wizard-forms/wizard-forms.component.ts").default,
                                     lang: "ts",
                                 },
                             ],
@@ -57,7 +57,7 @@ export const ROUTES: Array<Route> = [
                 path: "api",
                 component: ApiListComponent,
                 data: {
-                    sources: [require("!raw-loader!../../../../../../../lib/src/wizard/wizard.module.ts")],
+                    sources: [require("!raw-loader!../../../../../../../lib/src/wizard/wizard.module.ts").default],
                 },
             },
         ],

--- a/projects/ng-components-docs/src/app/utils/arrayFunctions.ts
+++ b/projects/ng-components-docs/src/app/utils/arrayFunctions.ts
@@ -1,0 +1,5 @@
+export function sortArray<T>(array: Array<T>, sortBy: keyof T): Array<T> {
+    return array.sort((first: T, second: T) => {
+        return String(first[sortBy]).localeCompare(String(second[sortBy]), "en", { sensitivity: "base" });
+    });
+}


### PR DESCRIPTION
The error comes from her https://webpack.js.org/loaders/raw-loader/#esmodule. By default raw-loader import using esModule and can be turn off as explained in the link. Alternatively you can return the .default when using inline. 

`require("!raw-loader!../your-file-source).default;`