### PR TITLE
fix: modal footer, body and header occupying space even if empty

### DIFF
--- a/projects/ng-components/lib/modal/modal.component.scss
+++ b/projects/ng-components/lib/modal/modal.component.scss
@@ -88,6 +88,16 @@ div.ac.modal.modal-fullscreen {
     }
 }
 
+.ac.modal {
+    .modal-header,
+    .modal-body,
+    .modal-footer {
+        &:empty {
+            display: none;
+        }
+    }
+}
+
 @keyframes fade-in-modal-container {
     0% {
         display: none;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14928743/100724342-bcab0880-33fd-11eb-8dec-eba68b45fff1.png)
