### PR TITLE
Bug on Dropdown Component when Native is True

### DIFF
--- a/projects/ng-components/lib/dropdown/dropdown.component.ts
+++ b/projects/ng-components/lib/dropdown/dropdown.component.ts
@@ -400,6 +400,9 @@ export class DropdownComponent implements ControlValueAccessor, OnChanges, OnDes
             this.nativeOnChange && this.nativeOnChange(event);
             this.selectedValue = items;
         }
+
+        this.onChangeCallback && this.onChangeCallback(this.selectedValue);
+        this.onTouchedCallback && this.onTouchedCallback();
     }
 
     /** Function which handles the logic of setting the non-native onChange prop (and sets the internal selected value as well) */


### PR DESCRIPTION
Callbacks provided by Angular's Control Value Accessor are not called during change events when input `native` flag is true.

Commits:
- fix: 🐛 invoke control value accessor callbacks for native